### PR TITLE
Bump Scriban from 6.5.7 to 6.6.0

### DIFF
--- a/framework/src/XiHan.Framework.Templating/XiHan.Framework.Templating.csproj
+++ b/framework/src/XiHan.Framework.Templating/XiHan.Framework.Templating.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Scriban" Version="6.5.7" />
+        <PackageReference Include="Scriban" Version="6.6.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: Scriban dependency-version: 6.6.0 dependency-type: direct:production ...