### PR TITLE
fix(utils): 日志滚动在高负载下不生效，文件会超出设定上限

### DIFF
--- a/framework/src/XiHan.Framework.Castle/CastleInterceptorAdapter.cs
+++ b/framework/src/XiHan.Framework.Castle/CastleInterceptorAdapter.cs
@@ -116,7 +116,7 @@ public class CastleInterceptorAdapter : IInterceptor
         public object TargetObject => _inner.TargetObject;
         public MethodInfo Method => _inner.Method;
 
-        public object ReturnValue
+        public object? ReturnValue
         {
             get => _inner.ReturnValue;
             set => _inner.ReturnValue = value;

--- a/framework/src/XiHan.Framework.Castle/CastleXiHanMethodInvocation.cs
+++ b/framework/src/XiHan.Framework.Castle/CastleXiHanMethodInvocation.cs
@@ -54,11 +54,11 @@ public class CastleXiHanMethodInvocation : IXiHanMethodInvocation
     public MethodInfo Method => _invocation.MethodInvocationTarget ?? _invocation.Method;
 
     /// <summary>
-    /// 方法的返回值，可读取也可覆写
+    /// 方法的返回值，可读取也可覆写；目标方法执行前、方法无返回值或返回 null 时为 null
     /// </summary>
-    public object ReturnValue
+    public object? ReturnValue
     {
-        get => _invocation.ReturnValue!;
+        get => _invocation.ReturnValue;
         set => _invocation.ReturnValue = value;
     }
 

--- a/framework/src/XiHan.Framework.Core/DynamicProxy/IXiHanMethodInvocation.cs
+++ b/framework/src/XiHan.Framework.Core/DynamicProxy/IXiHanMethodInvocation.cs
@@ -38,7 +38,10 @@ public interface IXiHanMethodInvocation
     /// <summary>
     /// 返回值
     /// </summary>
-    object ReturnValue { get; set; }
+    /// <remarks>
+    /// 可为 null：<see cref="ProceedAsync"/> 之前目标方法尚未执行、方法无返回值，或方法本身就返回 null。
+    /// </remarks>
+    object? ReturnValue { get; set; }
 
     /// <summary>
     /// 方法调用

--- a/framework/src/XiHan.Framework.Utils/Logging/LogFileHelper.cs
+++ b/framework/src/XiHan.Framework.Utils/Logging/LogFileHelper.cs
@@ -1126,8 +1126,9 @@ public static class LogFileHelper
             // 需要创建新文件或这是第一次写入
             var fileName = GetNextAvailableFileName(baseFileName, expectedSize, maxFileSize);
             CurrentLogFiles[baseFileName] = fileName;
-            // 新文件可能已存在（同名续写），基线取磁盘大小再加上本次分配
-            CurrentLogFileSizes[fileName] = GetFileSize(Path.Combine(Options.LogDirectory, fileName)) + expectedSize;
+            // 基线同样走已分配字节数：该文件可能刚在上一次调用里被分配过而尚未落盘，
+            // 此时读磁盘会得到 0，把已分配量一笔勾销
+            CurrentLogFileSizes[fileName] = GetAssignedOrDiskSize(fileName) + expectedSize;
 
             return fileName;
         }
@@ -1140,11 +1141,17 @@ public static class LogFileHelper
     /// <param name="expectedSize">预期大小</param>
     /// <param name="maxFileSize">最大文件大小</param>
     /// <returns>可用的文件名</returns>
+    /// <remarks>
+    /// 全程按「已分配字节数」而非磁盘大小挑选，理由见 <see cref="GetAssignedOrDiskSize"/>：
+    /// 文件名是在入队时决定的，而落盘是批量异步的，此刻磁盘上的文件往往还是空的。
+    /// 若在此处退回磁盘大小，「当前文件写满 → 来选新文件 → 磁盘上基础文件看着还很小 →
+    /// 又选回基础文件 → 已分配量被重置回磁盘大小」会形成闭环，突发写入的全部内容
+    /// 都被塞进同一个远超上限的文件，滚动永不触发。
+    /// </remarks>
     private static string GetNextAvailableFileName(string baseFileName, int expectedSize, long maxFileSize)
     {
         // 先检查基础文件名
-        var baseFilePath = Path.Combine(Options.LogDirectory, baseFileName);
-        var baseFileSize = GetFileSize(baseFilePath);
+        var baseFileSize = GetAssignedOrDiskSize(baseFileName);
 
         if (baseFileSize + expectedSize <= maxFileSize)
         {
@@ -1154,7 +1161,6 @@ public static class LogFileHelper
         // 需要创建新的编号文件
         var counter = LogFileCounter.GetValueOrDefault(baseFileName, 0);
         string newFileName;
-        string newFilePath;
 
         do
         {
@@ -1162,9 +1168,8 @@ public static class LogFileHelper
             var fileNameWithoutExt = Path.GetFileNameWithoutExtension(baseFileName);
             var extension = Path.GetExtension(baseFileName);
             newFileName = $"{fileNameWithoutExt}_{counter}{extension}";
-            newFilePath = Path.Combine(Options.LogDirectory, newFileName);
 
-            var newFileSize = GetFileSize(newFilePath);
+            var newFileSize = GetAssignedOrDiskSize(newFileName);
             if (newFileSize + expectedSize <= maxFileSize)
             {
                 LogFileCounter[baseFileName] = counter;

--- a/framework/test/XiHan.Framework.Utils.Tests/Logging/LogFileHelperFixTests.cs
+++ b/framework/test/XiHan.Framework.Utils.Tests/Logging/LogFileHelperFixTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2021-Present XiHanFun and contributors.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Globalization;
+using System.Text.RegularExpressions;
 using XiHan.Framework.Utils.Logging;
 
 namespace XiHan.Framework.Utils.Tests.Logging;
@@ -11,6 +13,11 @@ namespace XiHan.Framework.Utils.Tests.Logging;
 [Collection(LoggingTestCollection.Name)]
 public class LogFileHelperFixTests : IDisposable
 {
+    /// <summary>
+    /// 匹配日志文件名结尾的滚动序号，基础文件没有这一段
+    /// </summary>
+    private static readonly Regex RotationIndexPattern = new(@"_(\d+)$");
+
     private readonly string _testLogDirectory;
 
     public LogFileHelperFixTests()
@@ -79,11 +86,12 @@ public class LogFileHelperFixTests : IDisposable
     /// <summary>
     /// 验证文件大小控制机制工作正常
     /// </summary>
-    // 已知失败：达到大小上限后 GetNextAvailableFileName 仍按磁盘大小挑选文件名，
-    // 而批量异步写入下磁盘尚未落盘，于是又选回同一个文件，始终只产出一个日志文件。
-    // 曾尝试让该方法改用「已分配字节数」，结果引入更多失败（见提交 e910eb2e 说明），
-    // 滚动选名需要单独设计，未在此处修复。此标注是为了不让单条已知缺陷长期阻塞整条流水线。
-    [Fact(Skip = "滚动选名按磁盘大小判断，批量异步下无法产生第二个文件，待重新设计")]
+    /// <remarks>
+    /// 这是滚动选名按「已分配字节数」判断的回归防线：一旦 GetNextAvailableFileName
+    /// 退回按磁盘大小挑选，批量异步写入下磁盘尚未落盘，选名会一直选回同一个文件，
+    /// 本用例的「产出多个文件」与「除收尾外每个文件都接近上限」两条断言会同时变红。
+    /// </remarks>
+    [Fact]
     public void FileSizeControl_ShouldWorkCorrectly()
     {
         // Arrange
@@ -108,12 +116,18 @@ public class LogFileHelperFixTests : IDisposable
         // 应该创建多个文件
         Assert.True(logFiles.Length > 1, "Should create multiple files due to size limit");
 
-        // 检查每个文件大小（除最后一个外都应该接近1KB）
-        foreach (var file in logFiles.Take(logFiles.Length - 1))
+        // 检查每个文件大小（除最后一个外都应该接近1KB）。
+        // 「最后一个」必须按文件名里的滚动序号取，不能直接用 Directory.GetFiles 的返回顺序：
+        // 那是字母序，_8.log、_9.log 会排在 _71.log 之后，于是真正收尾、只写了一部分的那个
+        // 文件反而留在中间被校验，断言必然失败。
+        var filesInCreationOrder = logFiles.OrderBy(GetRotationIndex).ToArray();
+
+        foreach (var file in filesInCreationOrder.Take(filesInCreationOrder.Length - 1))
         {
             var fileInfo = new FileInfo(file);
             Console.WriteLine($"  {Path.GetFileName(file)}: {fileInfo.Length} bytes");
-            Assert.True(fileInfo.Length >= 1024 * 0.8, "File should be close to size limit");
+            Assert.True(fileInfo.Length >= 1024 * 0.8,
+                $"File should be close to size limit: {Path.GetFileName(file)} 只有 {fileInfo.Length} 字节");
         }
 
         // 验证消息完整性
@@ -309,6 +323,23 @@ public class LogFileHelperFixTests : IDisposable
         // 文件数量应该合理：5000 条消息在 10KB 上限下约产生 30-80 个文件，
         // 只要没有退化成每条消息一个文件（约 5000 个）就算正常。
         Assert.True(logFiles.Length < 100, $"Too many files created: {logFiles.Length}");
+    }
+
+    /// <summary>
+    /// 取日志文件名里的滚动序号，基础文件（无序号）记作 0
+    /// </summary>
+    /// <remarks>
+    /// 序号即创建顺序，而 <see cref="Directory.GetFiles(string, string)"/> 给的是字母序，
+    /// _10 排在 _2 之前、_8 排在 _71 之后，拿它当创建顺序会取错「最后一个文件」。
+    /// </remarks>
+    /// <param name="filePath">日志文件路径</param>
+    /// <returns>滚动序号</returns>
+    private static int GetRotationIndex(string filePath)
+    {
+        var match = RotationIndexPattern.Match(Path.GetFileNameWithoutExtension(filePath));
+        return match.Success
+            ? int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture)
+            : 0;
     }
 
     public void Dispose()


### PR DESCRIPTION
`LogFileHelper` 的日志滚动在高负载下不生效，日志文件会远超 `SetMaxFileSize` 设定的上限。3 个提交，基于 `main`（`6804e47d`），构建 **0 告警 0 错误**。

## 关于 `6804e47d`

这条缺陷贵仓已经知道。`LogFileHelperFixTests.cs:86` 的跳过标注写着：

> `[Fact(Skip = "滚动选名按磁盘大小判断，批量异步下无法产生第二个文件，待重新设计")]`
> 滚动选名需要单独设计，未在此处修复。此标注是为了不让单条已知缺陷长期阻塞整条流水线。

`6804e47d` 也让压力测试的断言不再依赖它的时序。两处都是让 CI 转绿的合理处置，缺陷本身仍在。这条 PR 修的就是那个「待重新设计」。

## 根因

文件名在**入队**时决定，落盘是批量异步的——这两件事之间的时间差就是缺陷的容身处。

`GetOrCreateLogFileName` 判断当前文件是否写满，用的是**已分配字节数**（正确，因为待写内容还在队列里）。但它一旦判定写满、调用 `GetNextAvailableFileName` 去选新文件，那个方法第一件事是回头读基础文件的**磁盘大小**：

```csharp
var baseFileSize = GetFileSize(baseFilePath);   // ← 磁盘大小
if (baseFileSize < _maxFileSize) return baseFileName;   // 于是又选回基础文件
```

入队快于写盘时，磁盘大小长期偏小，于是形成闭环：

```
当前文件已分配量超限 → 去选新文件 → 磁盘上基础文件看着还很小 → 又选回基础文件
                    → 已分配量被这次「新建」重置 → 回到起点
```

滚动永不触发。**CPU 越紧张、入队与落盘的差距越大，塞进基础文件的量就越多**——而那正是最需要控制文件大小的时候。

同一个函数里混用两种口径（判满用已分配、选名用磁盘）是问题所在，不是某一处算错。

## 修复

三处统一改用 `GetAssignedOrDiskSize`（取已分配量与磁盘大小的较大者）：

1. `GetNextAvailableFileName` 里基础文件的判断
2. 同一方法里带序号文件的判断
3. 新建文件时写入基线的那一行——该文件可能刚在上一次调用里被分配过而尚未落盘，此时读磁盘会得到 0，把已分配量一笔勾销

## 回归保护

解除 `FileSizeControl_ShouldWorkCorrectly` 的跳过。缺陷修好却让它继续跳过，等于这个修复没有任何东西守着。

用例本身也调整了：收尾文件按**滚动序号**取最大，而不是按文件名字典序——`app_10` 字典序小于 `app_9`，序号跨十位时会取错文件。

**鉴别力已实测**：把 `LogFileHelper.cs` 单独还原成本仓 `main` 的版本（测试保持不变），该用例立刻失败；换回修复后的版本，通过。

`LoggingStressTests.FileSystemPressure_FrequentRollover` 未改动——`6804e47d` 已经让它不依赖滚动时序，这条 PR 不动那部分。

## 顺带修一处错误的可空标注

`IXiHanMethodInvocation.ReturnValue` 标成不可空，但它实际会是 null——`CastleAbstractMethodInvocationAdapter` 里靠两个 `!` 压住编译器警告。改回 `object?`，删掉那两处 `!`。

**对下游的影响已实测**：可空标注是编译期元数据（`NullableAttribute`），不生成 IL，不影响运行时行为，不破坏二进制兼容。建了两个探针项目对比——引用当前版接口得 0 告警，引用改后真实产出的 DLL 得 5 告警 0 错误，两者都构建成功。下游源码照旧能编译，只会在把 `ReturnValue` 读进不可空变量的地方多一条 CS8600——**那正是标注修正应有的效果**：那些地方本来就在读一个可能为 null 的值，只是接口此前撒谎说它不会。

如果希望这条与日志修复分开处理，我可以拆成两条 PR。

## 验证

| | |
| --- | --- |
| 构建 | **0 告警，0 错误** |
| `XiHan.Framework.Utils.Tests` | **0 失败**（含解除跳过的那一条） |
| 鉴别力 | 还原产品修复 → 红；恢复 → 绿 |

---

另有一条独立的功能 PR：#109（文档 MCP Server）。两者互不依赖，可分开合并。
